### PR TITLE
fix: correctly apply prettier script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "webpack --watch --config webpack.dev.cjs",
     "build": "webpack --config webpack.prod.cjs",
     "lint": "eslint --ext .ts,.js --max-warnings=0 .",
-    "prettier": "prettier --write",
+    "prettier": "prettier . --write",
     "test": "c8 mocha ./test/setup.js ./test/**/*.js"
   },
   "type": "module",


### PR DESCRIPTION
Previously, running `npm run prettier` would show help in the terminal rather than format the files. This is because the directory was not specified in the prettier script. Providing the directory fixes the problem and the script correctly formats the files.